### PR TITLE
feat(add): add folder support to `plumb add`

### DIFF
--- a/plumb/Cargo.lock
+++ b/plumb/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "time",
+ "walkdir",
 ]
 
 [[package]]
@@ -587,6 +588,15 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -777,6 +787,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +846,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/plumb/Cargo.toml
+++ b/plumb/Cargo.toml
@@ -11,6 +11,7 @@ rand = "0.10.0"
 strata-rs = "0.4.3"
 thiserror = "2.0.18"
 time = "0.3.47"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/plumb/src/cli.rs
+++ b/plumb/src/cli.rs
@@ -31,7 +31,11 @@ pub enum Commands {
 
     /// Add a file (or a folder with -f --folder) to the current session's queue.
     Add {
-        // TODO: ADD FOLDER LATER
+        /// Treat the given path as a folder,
+        /// and enqueue all files recursively.
+        #[arg(short = 'f', long = "folder", verbatim_doc_comment)]
+        folder: bool,
+
         /// Path to the file to add.
         /// Example: "src/auth/guards.rs"
         #[arg(verbatim_doc_comment)]
@@ -55,7 +59,7 @@ pub fn run() -> Result<(), PlumbError> {
 
     match cli.command {
         Commands::Start { name } => plumb_start(name)?,
-        Commands::Add { file } => plumb_add(file)?,
+        Commands::Add { folder, file } => plumb_add(file, folder)?,
         Commands::Status {} => plumb_status()?,
         Commands::Rm { file } => plumb_rm(file)?,
     }

--- a/plumb/src/commands/add.rs
+++ b/plumb/src/commands/add.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::{
-    fs::{InputError, normalize_rel_path},
+    fs::{
+        InputError, collect_folder_files, lexical_normalize, normalize_rel_path_from_cwd,
+        to_slash_path,
+    },
     store::items::{Item, State, StoreError, active_session_id, load_items, save_items},
     workspace::resolve_workspace_root,
 };
@@ -22,21 +25,89 @@ pub enum AddError {
     UnknownError(String),
 }
 
-pub fn plumb_add(file: String) -> Result<(), AddError> {
-    let cwd = &std::env::current_dir().map_err(|e| AddError::UnknownError(e.to_string()))?;
+pub fn plumb_add(file: String, folder: bool) -> Result<(), AddError> {
+    let cwd = std::env::current_dir().map_err(|e| AddError::UnknownError(e.to_string()))?;
+    plumb_add_from_cwd(&cwd, file, folder, |root, session_id, items| {
+        save_items(root, session_id, items)
+    })
+}
+
+fn plumb_add_from_cwd<F>(
+    cwd: &Path,
+    file: String,
+    folder: bool,
+    mut save_items_fn: F,
+) -> Result<(), AddError>
+where
+    F: FnMut(&Path, &str, &[Item]) -> Result<(), StoreError>,
+{
     let root = resolve_workspace_root(cwd).map_err(|e| AddError::UnknownError(e.to_string()))?;
 
     let session_id = active_session_id(&root).map_err(|e| match e {
         StoreError::NoActiveSession => AddError::NoActiveSession(
-            "no active session found, please start a session first".to_string(),
+            "no active session found, use `plumb start` to start a session".to_string(),
         ),
-        _ => AddError::StoreError(e),
+        other => AddError::StoreError(other),
     })?;
-    let normalized_path = normalize_rel_path(&root, Path::new(&file))?;
+    let normalized_path = normalize_rel_path_from_cwd(&root, Path::new(&file), cwd)?;
 
-    let items = load_items(&root)?;
+    let mut items = load_items(&root)?;
 
-    if check_duplicates(&items, &normalized_path) {
+    if folder {
+        let added_count = plumb_add_folder(&mut items, &normalized_path, &session_id, &root)?;
+        if added_count > 0 {
+            save_items_fn(&root, &session_id, &items).map_err(AddError::StoreError)?;
+        }
+
+        return Ok(());
+    }
+
+    if root.join(&normalized_path).is_dir() {
+        return Err(AddError::InputError(InputError::InvalidPath(format!(
+            "path is a directory: {}",
+            normalized_path
+        ))));
+    }
+
+    plumb_add_file(&mut items, &normalized_path)?;
+    save_items_fn(&root, &session_id, &items).map_err(AddError::StoreError)?;
+    println!("Added file: [{}] {}", session_id, normalized_path);
+
+    Ok(())
+}
+
+fn plumb_add_folder(
+    items: &mut Vec<Item>,
+    normalized_path: &String,
+    session_id: &str,
+    root: &Path,
+) -> Result<usize, AddError> {
+    let folder_path = root.join(normalized_path);
+
+    let files =
+        collect_folder_files(&folder_path).map_err(|e| AddError::UnknownError(e.to_string()))?;
+
+    println!("Added folder: [{}] {}", session_id, normalized_path);
+    println!();
+    println!("Files found: {}", files.len());
+
+    let mut added_count = 0usize;
+    for file in files {
+        let file_rel_path = normalize_rel_path_from_cwd(root, &file, root)?;
+        match plumb_add_file(items, &file_rel_path) {
+            Ok(()) => added_count += 1,
+            Err(AddError::FileAlreadyInQueue(_)) => {
+                println!("  [SKIP] file already in queue: {}", file_rel_path)
+            }
+            Err(e) => println!("  [ERROR] failed to add file: {}: {}", file_rel_path, e),
+        }
+    }
+
+    Ok(added_count)
+}
+
+fn plumb_add_file(items: &mut Vec<Item>, normalized_path: &str) -> Result<(), AddError> {
+    if check_duplicates(items, normalized_path) {
         return Err(AddError::FileAlreadyInQueue(format!(
             "file already in queue: {}",
             normalized_path
@@ -44,33 +115,57 @@ pub fn plumb_add(file: String) -> Result<(), AddError> {
     }
 
     let new_item = Item {
-        id: next_id(&items),
-        rel_path: normalized_path.clone(),
+        id: next_id(items),
+        rel_path: normalized_path.to_string(),
         state: State::Todo,
     };
 
-    let mut new_items = items;
-    new_items.push(new_item);
-
-    save_items(&root, &session_id, &new_items)?;
-
-    println!("Added: [{}] {}", session_id, normalized_path);
+    items.push(new_item);
 
     Ok(())
 }
 
 fn check_duplicates(items: &[Item], normalized_path: &str) -> bool {
-    items.iter().any(|item| item.rel_path == normalized_path)
+    let candidate = normalize_item_path(normalized_path);
+    items
+        .iter()
+        .any(|item| normalize_item_path(&item.rel_path) == candidate)
 }
 
 fn next_id(items: &[Item]) -> usize {
     items.iter().map(|item| item.id).max().unwrap_or(0) + 1
 }
 
+fn normalize_item_path(path: &str) -> String {
+    to_slash_path(&lexical_normalize(Path::new(path)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::store::items::State;
+    use std::cell::Cell;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_workspace_with_active_session() -> TempDir {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let session_id = "deadbeef";
+
+        fs::create_dir_all(root.join(".plumb/sessions").join(session_id)).unwrap();
+        fs::write(root.join(".plumb/active"), session_id).unwrap();
+
+        temp_dir
+    }
+
+    fn ids_and_paths(root: &Path) -> Vec<(usize, String)> {
+        let items = load_items(root).unwrap();
+        items
+            .into_iter()
+            .map(|item| (item.id, item.rel_path))
+            .collect()
+    }
 
     #[test]
     fn test_next_id_from_existing_items() {
@@ -138,5 +233,132 @@ mod tests {
             state: State::Todo,
         }];
         assert!(check_duplicates(&items, "x.rs"));
+    }
+
+    #[test]
+    fn duplicates_detected_after_normalization() {
+        let items = vec![Item {
+            id: 1,
+            rel_path: "src/./a.rs".to_string(),
+            state: State::Todo,
+        }];
+        assert!(check_duplicates(&items, "src/a.rs"));
+    }
+
+    #[test]
+    fn next_id_continues_from_max_even_if_items_unsorted() {
+        let items = vec![
+            Item {
+                id: 10,
+                rel_path: "a.rs".to_string(),
+                state: State::Todo,
+            },
+            Item {
+                id: 3,
+                rel_path: "b.rs".to_string(),
+                state: State::Todo,
+            },
+            Item {
+                id: 7,
+                rel_path: "c.rs".to_string(),
+                state: State::Todo,
+            },
+        ];
+
+        assert_eq!(next_id(&items), 11);
+    }
+
+    #[test]
+    fn add_without_folder_rejects_directory_path() {
+        let workspace = create_workspace_with_active_session();
+        let root = workspace.path();
+
+        fs::create_dir_all(root.join("src")).unwrap();
+
+        let result = plumb_add_from_cwd(root, "src".to_string(), false, save_items);
+        let err = result.unwrap_err();
+
+        assert!(matches!(
+            err,
+            AddError::InputError(InputError::InvalidPath(msg)) if msg.contains("directory")
+        ));
+    }
+
+    #[test]
+    fn add_with_folder_accepts_relative_and_absolute_paths_same_result() {
+        let relative_workspace = create_workspace_with_active_session();
+        let relative_root = relative_workspace.path();
+        fs::create_dir_all(relative_root.join("src/deep")).unwrap();
+        fs::write(relative_root.join("src/deep/a.rs"), "").unwrap();
+        fs::write(relative_root.join("src/b.rs"), "").unwrap();
+
+        plumb_add_from_cwd(relative_root, "src".to_string(), true, save_items).unwrap();
+        let relative_items = ids_and_paths(relative_root);
+
+        let absolute_workspace = create_workspace_with_active_session();
+        let absolute_root = absolute_workspace.path();
+        fs::create_dir_all(absolute_root.join("src/deep")).unwrap();
+        fs::write(absolute_root.join("src/deep/a.rs"), "").unwrap();
+        fs::write(absolute_root.join("src/b.rs"), "").unwrap();
+
+        let abs_folder = absolute_root.join("src").to_string_lossy().to_string();
+        plumb_add_from_cwd(absolute_root, abs_folder, true, save_items).unwrap();
+        let absolute_items = ids_and_paths(absolute_root);
+
+        assert_eq!(relative_items, absolute_items);
+    }
+
+    #[test]
+    fn add_folder_persists_items_once_per_invocation() {
+        let workspace = create_workspace_with_active_session();
+        let root = workspace.path();
+
+        fs::create_dir_all(root.join("src/deep")).unwrap();
+        fs::write(root.join("src/a.rs"), "").unwrap();
+        fs::write(root.join("src/deep/b.rs"), "").unwrap();
+
+        let save_count = Cell::new(0usize);
+        plumb_add_from_cwd(
+            root,
+            "src".to_string(),
+            true,
+            |save_root, session_id, items| {
+                save_count.set(save_count.get() + 1);
+                save_items(save_root, session_id, items)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(save_count.get(), 1, "folder add should save once");
+    }
+
+    #[test]
+    fn add_folder_with_zero_eligible_files_is_noop() {
+        let workspace = create_workspace_with_active_session();
+        let root = workspace.path();
+
+        fs::create_dir_all(root.join("batch/.git")).unwrap();
+        fs::create_dir_all(root.join("batch/node_modules/pkg")).unwrap();
+        fs::create_dir_all(root.join("batch/target/build")).unwrap();
+        fs::create_dir_all(root.join("batch/.plumb/cache")).unwrap();
+        fs::write(root.join("batch/.git/skip.txt"), "").unwrap();
+        fs::write(root.join("batch/node_modules/pkg/skip.js"), "").unwrap();
+        fs::write(root.join("batch/target/build/skip.rs"), "").unwrap();
+        fs::write(root.join("batch/.plumb/cache/skip.txt"), "").unwrap();
+
+        let save_count = Cell::new(0usize);
+        plumb_add_from_cwd(
+            root,
+            "batch".to_string(),
+            true,
+            |save_root, session_id, items| {
+                save_count.set(save_count.get() + 1);
+                save_items(save_root, session_id, items)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(save_count.get(), 0, "no-op folder add should not persist");
+        assert!(load_items(root).unwrap().is_empty());
     }
 }

--- a/plumb/src/fs.rs
+++ b/plumb/src/fs.rs
@@ -31,6 +31,14 @@ pub fn normalize_rel_path(root: &Path, input: &Path) -> Result<String, InputErro
     let cwd = std::env::current_dir()
         .map_err(|e| InputError::InvalidPath(format!("failed to get current directory: {e}")))?;
 
+    normalize_rel_path_from_cwd(root, input, &cwd)
+}
+
+pub(crate) fn normalize_rel_path_from_cwd(
+    root: &Path,
+    input: &Path,
+    cwd: &Path,
+) -> Result<String, InputError> {
     let root_abs = if root.is_absolute() {
         root.to_path_buf()
     } else {
@@ -57,7 +65,38 @@ pub fn normalize_rel_path(root: &Path, input: &Path) -> Result<String, InputErro
     Ok(to_slash_path(rel))
 }
 
-fn lexical_normalize(path: &Path) -> PathBuf {
+pub fn collect_folder_files(path: &Path) -> Result<Vec<PathBuf>, FsError> {
+    if !path.is_dir() {
+        return Err(FsError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("path is not a directory: {}", path.to_string_lossy()),
+        )));
+    }
+
+    let mut files = Vec::new();
+
+    let should_skip_dir = |p: &Path| {
+        matches!(
+            p.file_name().and_then(|n| n.to_str()),
+            Some(".plumb" | ".git" | "target" | "node_modules")
+        )
+    };
+
+    for entry in walkdir::WalkDir::new(path)
+        .into_iter()
+        .filter_entry(|e| !should_skip_dir(e.path()))
+    {
+        let entry = entry.map_err(|e| FsError::IoError(e.into()))?;
+        if entry.file_type().is_file() {
+            files.push(entry.path().to_path_buf());
+        }
+    }
+    files.sort_by_cached_key(|p| to_slash_path(&lexical_normalize(p)));
+
+    Ok(files)
+}
+
+pub(crate) fn lexical_normalize(path: &Path) -> PathBuf {
     let mut out = PathBuf::new();
 
     for comp in path.components() {
@@ -77,7 +116,7 @@ fn lexical_normalize(path: &Path) -> PathBuf {
     out
 }
 
-fn to_slash_path(path: &Path) -> String {
+pub(crate) fn to_slash_path(path: &Path) -> String {
     let s = path.to_string_lossy().replace('\\', "/");
     let s = s.trim_start_matches('/').to_string();
 
@@ -92,6 +131,8 @@ fn to_slash_path(path: &Path) -> String {
 mod tests {
     use super::*;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::{PermissionsExt, symlink};
     use tempfile::TempDir;
 
     #[test]
@@ -221,6 +262,149 @@ mod tests {
 
         let result = result.unwrap();
         assert_eq!(result, "nested/deep/t3");
+    }
+
+    #[test]
+    fn collect_folder_files_rejects_non_dir_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("file.rs");
+        fs::write(&file_path, "").unwrap();
+
+        let result = collect_folder_files(&file_path);
+        let err = result.unwrap_err();
+        assert!(matches!(err, FsError::IoError(_)));
+    }
+
+    #[test]
+    fn collect_folder_files_excludes_dirs_anywhere_in_tree() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::create_dir_all(root.join("src/deep")).unwrap();
+        fs::create_dir_all(root.join("src/.git")).unwrap();
+        fs::create_dir_all(root.join("src/node_modules/pkg")).unwrap();
+        fs::create_dir_all(root.join("src/target/build")).unwrap();
+        fs::create_dir_all(root.join("src/.plumb/cache")).unwrap();
+
+        fs::write(root.join("src/deep/keep.rs"), "").unwrap();
+        fs::write(root.join("src/.git/ignore.rs"), "").unwrap();
+        fs::write(root.join("src/node_modules/pkg/index.js"), "").unwrap();
+        fs::write(root.join("src/target/build/tmp.rs"), "").unwrap();
+        fs::write(root.join("src/.plumb/cache/meta.rs"), "").unwrap();
+
+        let files = collect_folder_files(root).unwrap();
+        let rels: Vec<_> = files
+            .iter()
+            .map(|p| to_slash_path(p.strip_prefix(root).unwrap()))
+            .collect();
+
+        assert_eq!(rels, vec!["src/deep/keep.rs"]);
+    }
+
+    #[test]
+    fn collect_folder_files_excludes_when_root_is_excluded_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let excluded_root = temp_dir.path().join(".git");
+        fs::create_dir_all(&excluded_root).unwrap();
+        fs::write(excluded_root.join("config"), "").unwrap();
+
+        let files = collect_folder_files(&excluded_root).unwrap();
+        assert!(
+            files.is_empty(),
+            "excluded root directory should not yield files"
+        );
+    }
+
+    #[test]
+    fn collect_folder_files_sorts_by_normalized_workspace_relative_slash_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::create_dir_all(root.join("src/nested")).unwrap();
+        fs::create_dir_all(root.join("a")).unwrap();
+        fs::write(root.join("src/nested/z.rs"), "").unwrap();
+        fs::write(root.join("src/a.rs"), "").unwrap();
+        fs::write(root.join("a/main.rs"), "").unwrap();
+
+        let files = collect_folder_files(root).unwrap();
+        let rels: Vec<_> = files
+            .iter()
+            .map(|p| to_slash_path(p.strip_prefix(root).unwrap()))
+            .collect();
+
+        assert_eq!(rels, vec!["a/main.rs", "src/a.rs", "src/nested/z.rs"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walkdir_does_not_follow_symlink_dirs_no_cycles() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::create_dir_all(root.join("real")).unwrap();
+        fs::write(root.join("real/file.rs"), "").unwrap();
+        symlink(root, root.join("real/loop")).unwrap();
+
+        let files = collect_folder_files(root).unwrap();
+        let rels: Vec<_> = files
+            .iter()
+            .map(|p| to_slash_path(p.strip_prefix(root).unwrap()))
+            .collect();
+
+        assert_eq!(rels, vec!["real/file.rs"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_file_policy_is_consistent() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(root.join("real.rs"), "").unwrap();
+        symlink(root.join("real.rs"), root.join("linked.rs")).unwrap();
+
+        let files = collect_folder_files(root).unwrap();
+        let rels: Vec<_> = files
+            .iter()
+            .map(|p| to_slash_path(p.strip_prefix(root).unwrap()))
+            .collect();
+
+        assert!(rels.contains(&"real.rs".to_string()));
+        assert!(
+            !rels.contains(&"linked.rs".to_string()),
+            "symlinked file entries should be skipped"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_folder_files_unreadable_entry_behavior() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        let blocked = root.join("blocked");
+        fs::create_dir_all(blocked.join("inner")).unwrap();
+        fs::write(blocked.join("inner/secret.rs"), "").unwrap();
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = collect_folder_files(root);
+
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o755)).unwrap();
+
+        match result {
+            Ok(files) => {
+                let rels: Vec<_> = files
+                    .iter()
+                    .map(|p| to_slash_path(p.strip_prefix(root).unwrap()))
+                    .collect();
+                assert!(
+                    !rels.iter().any(|p| p.starts_with("blocked/")),
+                    "unreadable entries should be skipped if traversal continues"
+                );
+            }
+            Err(FsError::IoError(_)) => {}
+            Err(other) => panic!("unexpected error variant: {other}"),
+        }
     }
 
     #[test]

--- a/plumb/src/store/items.rs
+++ b/plumb/src/store/items.rs
@@ -37,8 +37,17 @@ pub fn active_session_id(root: &Path) -> Result<String, StoreError> {
     })?;
     let session_file = workspace_root.join(".plumb").join("active");
 
-    let content = std::fs::read_to_string(&session_file)
-        .map_err(|e| StoreError::ReadError(format!("Could not read active file: {e}")))?;
+    if !session_file.is_file() {
+        return Err(StoreError::NoActiveSession);
+    }
+
+    let content = std::fs::read_to_string(&session_file).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            StoreError::NoActiveSession
+        } else {
+            StoreError::ReadError(format!("Could not read active file: {e}"))
+        }
+    })?;
 
     let session_id = content.trim().to_string();
     if session_id.is_empty() {
@@ -216,7 +225,7 @@ mod tests {
 
         let result = active_session_id(workspace.path());
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), StoreError::ReadError(_)));
+        assert!(matches!(result.unwrap_err(), StoreError::NoActiveSession));
     }
 
     #[test]

--- a/plumb/tests/integration_add.rs
+++ b/plumb/tests/integration_add.rs
@@ -27,6 +27,33 @@ fn read_items(root: &std::path::Path) -> Value {
     decode(&data).unwrap()
 }
 
+fn item_ids_and_paths(items_value: Value) -> (Vec<i64>, Vec<String>) {
+    let Value::List(items) = items_value else {
+        panic!("items should be a list");
+    };
+
+    let mut ids = Vec::new();
+    let mut paths = Vec::new();
+
+    for item in items {
+        let Value::Map(m) = item else {
+            panic!("item should be a map");
+        };
+
+        let Value::Int(id) = m.get("id").unwrap() else {
+            panic!("id should be an int");
+        };
+        let Value::String(path) = m.get("rel_path").unwrap() else {
+            panic!("rel_path should be a string");
+        };
+
+        ids.push(*id);
+        paths.push(path.clone());
+    }
+
+    (ids, paths)
+}
+
 #[test]
 fn add_creates_items_file() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -281,4 +308,240 @@ fn status_shows_correct_counts() {
         "status should show 0 done items, got: {}",
         stdout
     );
+}
+
+#[test]
+fn add_folder_happy_path_excludes_dirs_and_orders_lexicographically() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+
+    fs::create_dir_all(root.join("src/nested")).unwrap();
+    fs::create_dir_all(root.join("src/.git")).unwrap();
+    fs::create_dir_all(root.join("src/node_modules/pkg")).unwrap();
+    fs::create_dir_all(root.join("src/target/build")).unwrap();
+    fs::create_dir_all(root.join("src/.plumb/cache")).unwrap();
+
+    fs::write(root.join("src/z.rs"), "").unwrap();
+    fs::write(root.join("src/a.rs"), "").unwrap();
+    fs::write(root.join("src/nested/m.rs"), "").unwrap();
+    fs::write(root.join("src/.git/ignored.rs"), "").unwrap();
+    fs::write(root.join("src/node_modules/pkg/ignored.js"), "").unwrap();
+    fs::write(root.join("src/target/build/ignored.rs"), "").unwrap();
+    fs::write(root.join("src/.plumb/cache/ignored.txt"), "").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("-f")
+        .arg("src")
+        .assert()
+        .success();
+
+    let (ids, paths) = item_ids_and_paths(read_items(root));
+    assert_eq!(ids, vec![1, 2, 3]);
+    assert_eq!(
+        paths,
+        vec![
+            "src/a.rs".to_string(),
+            "src/nested/m.rs".to_string(),
+            "src/z.rs".to_string()
+        ]
+    );
+}
+
+#[test]
+fn add_folder_twice_is_deterministic_and_noop_on_second_run() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+
+    fs::create_dir_all(root.join("src/deep")).unwrap();
+    fs::write(root.join("src/b.rs"), "").unwrap();
+    fs::write(root.join("src/deep/a.rs"), "").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("-f")
+        .arg("src")
+        .assert()
+        .success();
+
+    let first = item_ids_and_paths(read_items(root));
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("-f")
+        .arg("src")
+        .assert()
+        .success();
+
+    let second = item_ids_and_paths(read_items(root));
+
+    assert_eq!(first, second, "second folder add should be a no-op");
+}
+
+#[test]
+fn add_folder_id_continuation_after_single_file_add() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+
+    fs::write(root.join("first.rs"), "").unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/b.rs"), "").unwrap();
+    fs::write(root.join("src/a.rs"), "").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("first.rs")
+        .assert()
+        .success();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("-f")
+        .arg("src")
+        .assert()
+        .success();
+
+    let (ids, paths) = item_ids_and_paths(read_items(root));
+    assert_eq!(ids, vec![1, 2, 3]);
+    assert_eq!(
+        paths,
+        vec![
+            "first.rs".to_string(),
+            "src/a.rs".to_string(),
+            "src/b.rs".to_string()
+        ]
+    );
+}
+
+#[test]
+fn add_folder_requires_active_session() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "").unwrap();
+
+    let output = plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("-f")
+        .arg("src")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "should fail without active session"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr
+            .to_lowercase()
+            .contains("use `plumb start` to start a session"),
+        "expected rm/status-style no-active-session message, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.to_lowercase().contains("no active session found"),
+        "expected no active session message, got: {}",
+        stderr
+    );
+    assert!(
+        !stderr
+            .to_lowercase()
+            .contains("failed to read the active file"),
+        "expected active-session related error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn add_folder_with_only_excluded_files_adds_nothing() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+
+    fs::create_dir_all(root.join("batch/.git")).unwrap();
+    fs::create_dir_all(root.join("batch/node_modules/pkg")).unwrap();
+    fs::create_dir_all(root.join("batch/target/build")).unwrap();
+    fs::create_dir_all(root.join("batch/.plumb/cache")).unwrap();
+    fs::write(root.join("batch/.git/skip.txt"), "").unwrap();
+    fs::write(root.join("batch/node_modules/pkg/skip.js"), "").unwrap();
+    fs::write(root.join("batch/target/build/skip.rs"), "").unwrap();
+    fs::write(root.join("batch/.plumb/cache/skip.txt"), "").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("-f")
+        .arg("batch")
+        .assert()
+        .success();
+
+    let (ids, paths) = item_ids_and_paths(read_items(root));
+    assert!(ids.is_empty());
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn add_folder_dot_path_behavior_is_defined() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+    fs::create_dir_all(root.join("target/build")).unwrap();
+
+    fs::write(root.join("root.rs"), "").unwrap();
+    fs::write(root.join("src/lib.rs"), "").unwrap();
+    fs::write(root.join(".git/ignored.txt"), "").unwrap();
+    fs::write(root.join("node_modules/pkg/ignored.js"), "").unwrap();
+    fs::write(root.join("target/build/ignored.rs"), "").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("-f")
+        .arg(".")
+        .assert()
+        .success();
+
+    let (ids, paths) = item_ids_and_paths(read_items(root));
+    assert_eq!(ids, vec![1, 2]);
+    assert_eq!(paths, vec!["root.rs".to_string(), "src/lib.rs".to_string()]);
 }


### PR DESCRIPTION
## Summary
Add recursive folder enqueue support to `plumb add` via `-f/--folder`, backed by `walkdir`, with deterministic file ordering, safer path normalization, and improved “no active session” handling.

## Changes
- Add `walkdir` dependency and implement recursive folder file collection with excluded dirs (`.plumb`, `.git`, `target`, `node_modules`) and sorted, normalized output.
- Extend CLI `add` command with `-f/--folder` flag and wire it through to the add command handler.
- Refactor add logic to support folder mode, batch saving (save once per invocation when items changed), and reject directory paths when not using `-f`.
- Improve duplicate detection by normalizing item paths before comparison.
- Introduce `normalize_rel_path_from_cwd` to make normalization testable and consistent across relative/absolute inputs.
- Update `active_session_id` to return `NoActiveSession` when `.plumb/active` is missing/not a file.
- Add comprehensive unit and integration tests covering folder add behavior, sorting, excludes, duplicates, ID continuation, no-op saves, and session requirements.

Closes #3 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--folder` flag to recursively enqueue files from directories into the queue.

* **Bug Fixes**
  * Improved duplicate detection accuracy and error messaging for invalid session states.

* **Tests**
  * Expanded test coverage with integration tests for folder operations, ID sequencing, and edge cases.

* **Chores**
  * Added walkdir dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->