### PR TITLE
feat(go): implement `plumb go` and baseline capturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ changed against that baseline. One file at a time, one session at a time.
 start [name]       begin a new session
 add <file>         enqueue a file as todo
 add -f <folder>    enqueue all files in a folder (recursive)
+rm <id|file>       removes a file from the queue
 status             show session progress
 go <id|file>       set item in_progress, capture baseline, open vim
 diff [id|file]     diff current file against baseline

--- a/docs/commands/go.md
+++ b/docs/commands/go.md
@@ -64,15 +64,13 @@ plumb go src/auth/guard.rs
 
 ## Notes
 
-- **Single in-progress rule.** Only one item may be `in_progress` at a time. If
-  another item is already `in_progress`, `plumb go` fails with an error. Run
-  `plumb done` on the current item first.
 - **File must exist.** If the file does not exist on disk, `plumb go` fails and
   the item stays `todo`.
 - **File must be readable.** If the file cannot be read (e.g. permission denied),
   `plumb go` fails and the item stays `todo`.
 - **Item must be `todo`.** Running `plumb go` on a `done` item is an error.
-- **Opens vim.** After capturing the baseline, Plumb opens the file in `vim`.
+- **Opens editor (defaults to vim).** After capturing the baseline, Plumb opens the
+  file in your editor. If none is set, it defaults to `vim`
   Plumb waits for vim to exit before returning control to the terminal.
 - Requires an active session.
 

--- a/plumb/src/cli.rs
+++ b/plumb/src/cli.rs
@@ -1,7 +1,9 @@
 use clap::{Parser, Subcommand};
 
 use crate::{
-    commands::{add::plumb_add, rm::plumb_rm, start::plumb_start, status::plumb_status},
+    commands::{
+        add::plumb_add, go::plumb_go, rm::plumb_rm, start::plumb_start, status::plumb_status,
+    },
     error::PlumbError,
 };
 
@@ -52,6 +54,15 @@ pub enum Commands {
 
     /// Prints the current session's queue of files to be refactored.
     Status {},
+
+    /// Opens the specified file in the editor, captures baseline, and updates status to "In
+    /// Progress".
+    Go {
+        /// File path or item ID of the file to refactor.
+        /// Example: "src/auth/guards.rs"
+        #[arg(verbatim_doc_comment)]
+        file: String,
+    },
 }
 
 pub fn run() -> Result<(), PlumbError> {
@@ -62,6 +73,7 @@ pub fn run() -> Result<(), PlumbError> {
         Commands::Add { folder, file } => plumb_add(file, folder)?,
         Commands::Status {} => plumb_status()?,
         Commands::Rm { file } => plumb_rm(file)?,
+        Commands::Go { file } => plumb_go(file)?,
     }
 
     Ok(())

--- a/plumb/src/commands/go.rs
+++ b/plumb/src/commands/go.rs
@@ -1,0 +1,558 @@
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::{
+    fs::{FsError, atomic_write},
+    helpers::{HelperError, resolve_item},
+    store::items::{Item, State, StoreError, active_session_id, load_items, save_items},
+    workspace::resolve_workspace_root,
+};
+
+#[derive(Error, Debug)]
+pub enum GoError {
+    #[error("{0}")]
+    AlreadyDone(String),
+    #[error("{0}")]
+    AlreadyInProgress(String),
+    #[error("{0}")]
+    NoActiveSession(String),
+    #[error("{0}")]
+    FileNotInQueue(String),
+    #[error("{0}")]
+    EditorError(String),
+    #[error("{0}")]
+    BaselineCaptureError(String),
+    #[error("{0}")]
+    HelperError(#[from] HelperError),
+    #[error("{0}")]
+    StoreError(#[from] StoreError),
+    #[error("{0}")]
+    FsError(#[from] FsError),
+    #[error("{0}")]
+    UnknownError(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GoAction {
+    ReopenInProgress,
+    StartTodo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GoPlan {
+    action: GoAction,
+    item_id: usize,
+    normalized_path: String,
+}
+
+pub fn plumb_go(target: String) -> Result<(), GoError> {
+    let cwd = std::env::current_dir().map_err(|e| GoError::UnknownError(e.to_string()))?;
+    plumb_go_from_cwd_with_ops(
+        &cwd,
+        target,
+        open_in_editor,
+        capture_baseline,
+        mark_item_in_progress,
+    )
+}
+
+fn plumb_go_from_cwd_with_ops<FOpen, FCapture, FMark>(
+    cwd: &Path,
+    target: String,
+    mut open_in_editor_fn: FOpen,
+    mut capture_baseline_fn: FCapture,
+    mut mark_item_in_progress_fn: FMark,
+) -> Result<(), GoError>
+where
+    FOpen: FnMut(&Path) -> Result<(), GoError>,
+    FCapture: FnMut(&Path, &str, usize, &str) -> Result<(), GoError>,
+    FMark: FnMut(&Path, &str, usize) -> Result<(), GoError>,
+{
+    let root = resolve_workspace_root(&cwd).map_err(|e| GoError::UnknownError(e.to_string()))?;
+
+    let session_id = active_session_id(&root).map_err(|_| {
+        GoError::NoActiveSession(
+            "no active session found, use `plumb start` to start a session".to_string(),
+        )
+    })?;
+
+    let items = load_items(&root)?;
+    let (item_id, normalized_path, state) =
+        resolve_item(&root, &items, &target).map_err(|e| match e {
+            HelperError::FileNotInQueue(msg) => GoError::FileNotInQueue(msg),
+            other => GoError::HelperError(other),
+        })?;
+
+    let plan = go_plan(&items, item_id, &normalized_path, state, || {
+        ensure_baseline_source_ready(&root, &normalized_path)
+    })?;
+
+    let full_path = root.join(&plan.normalized_path);
+
+    match plan.action {
+        GoAction::ReopenInProgress => {
+            open_in_editor_fn(&full_path)?;
+        }
+        GoAction::StartTodo => {
+            capture_baseline_fn(&root, &session_id, plan.item_id, &plan.normalized_path)?;
+            mark_item_in_progress_fn(&root, &session_id, plan.item_id)?;
+            open_in_editor_fn(&full_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn go_plan<F>(
+    items: &[Item],
+    item_id: usize,
+    normalized_path: &str,
+    state: State,
+    mut pre_baseline_check: F,
+) -> Result<GoPlan, GoError>
+where
+    F: FnMut() -> Result<(), GoError>,
+{
+    if state == State::Done {
+        return Err(GoError::AlreadyDone(format!(
+            "file is already marked as done: {}",
+            normalized_path
+        )));
+    }
+
+    if state == State::InProgress {
+        return Ok(GoPlan {
+            action: GoAction::ReopenInProgress,
+            item_id,
+            normalized_path: normalized_path.to_string(),
+        });
+    }
+
+    if let Some(in_progress_item) = items
+        .iter()
+        .find(|item| item.state == State::InProgress && item.id != item_id)
+    {
+        return Err(GoError::AlreadyInProgress(format!(
+            "another item is already in progress: [{}] {}",
+            in_progress_item.id, in_progress_item.rel_path
+        )));
+    }
+
+    pre_baseline_check()?;
+
+    Ok(GoPlan {
+        action: GoAction::StartTodo,
+        item_id,
+        normalized_path: normalized_path.to_string(),
+    })
+}
+
+fn open_in_editor(path: &Path) -> Result<(), GoError> {
+    open_in_editor_with(
+        path,
+        || std::env::var("EDITOR").ok(),
+        |editor, file_path| {
+            let status = std::process::Command::new(editor)
+                .arg(file_path)
+                .status()
+                .map_err(|e| GoError::EditorError(format!("failed to open editor: {}", e)))?;
+
+            if !status.success() {
+                return Err(GoError::EditorError(format!(
+                    "editor exited with status: {}",
+                    status
+                )));
+            }
+
+            Ok(())
+        },
+    )
+}
+
+fn open_in_editor_with<FEditor, FRun>(
+    path: &Path,
+    mut editor_from_env: FEditor,
+    mut run_editor: FRun,
+) -> Result<(), GoError>
+where
+    FEditor: FnMut() -> Option<String>,
+    FRun: FnMut(&str, &Path) -> Result<(), GoError>,
+{
+    let editor = editor_from_env()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "vim".to_string());
+    run_editor(&editor, path)
+}
+
+fn ensure_baseline_source_ready(root: &Path, item_path: &str) -> Result<(), GoError> {
+    let full_item_path = root.join(item_path);
+    if !full_item_path.exists() {
+        return Err(GoError::BaselineCaptureError(format!(
+            "file does not exist: {}",
+            item_path
+        )));
+    }
+    if full_item_path.is_dir() {
+        return Err(GoError::BaselineCaptureError(format!(
+            "cannot capture baseline for a folder: {}",
+            item_path
+        )));
+    }
+
+    std::fs::File::open(&full_item_path)
+        .map_err(|e| GoError::BaselineCaptureError(format!("failed to read file: {}", e)))?;
+
+    Ok(())
+}
+
+fn mark_item_in_progress(root: &Path, session_id: &str, item_id: usize) -> Result<(), GoError> {
+    let mut items = load_items(root)?;
+    let item = items
+        .iter_mut()
+        .find(|item| item.id == item_id)
+        .ok_or_else(|| GoError::FileNotInQueue(format!("no file with ID {} in queue", item_id)))?;
+
+    let rel_path = item.rel_path.clone();
+
+    item.state = State::InProgress;
+    save_items(root, session_id, &items)?;
+
+    println!("Started: [{}] {} (baseline captured)", item_id, rel_path);
+
+    Ok(())
+}
+
+fn capture_baseline(
+    root: &Path,
+    session_id: &str,
+    item_id: usize,
+    item_path: &str,
+) -> Result<(), GoError> {
+    ensure_baseline_source_ready(root, item_path)?;
+
+    let snapshot_path = root
+        .join(".plumb")
+        .join("sessions")
+        .join(session_id)
+        .join("snapshots")
+        .join(format!("{}.baseline", item_id));
+
+    let full_item_path = root.join(item_path);
+    let content = std::fs::read(&full_item_path)
+        .map_err(|e| GoError::BaselineCaptureError(format!("failed to read file: {}", e)))?;
+
+    atomic_write(&snapshot_path, &content)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::{cell::Cell, fs};
+    use tempfile::TempDir;
+
+    fn make_item(id: usize, rel_path: &str, state: State) -> Item {
+        Item {
+            id,
+            rel_path: rel_path.to_string(),
+            state,
+        }
+    }
+
+    fn create_workspace_with_items(items: &[Item]) -> (TempDir, String) {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let session_id = "deadbeef".to_string();
+
+        fs::create_dir_all(
+            root.join(".plumb/sessions")
+                .join(&session_id)
+                .join("snapshots"),
+        )
+        .unwrap();
+        fs::write(root.join(".plumb/active"), &session_id).unwrap();
+        save_items(root, &session_id, items).unwrap();
+
+        (temp_dir, session_id)
+    }
+
+    fn state_snapshot(root: &Path) -> Vec<(usize, String, State)> {
+        load_items(root)
+            .unwrap()
+            .into_iter()
+            .map(|item| (item.id, item.rel_path, item.state))
+            .collect()
+    }
+
+    #[test]
+    fn go_rejects_done_item() {
+        let items = vec![make_item(1, "done.rs", State::Done)];
+        let (workspace, _) = create_workspace_with_items(&items);
+        let root = workspace.path();
+
+        let open_calls = Cell::new(0usize);
+        let err = plumb_go_from_cwd_with_ops(
+            root,
+            "1".to_string(),
+            |_| {
+                open_calls.set(open_calls.get() + 1);
+                Ok(())
+            },
+            |_, _, _, _| Ok(()),
+            |_, _, _| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, GoError::AlreadyDone(msg) if msg.contains("done.rs")));
+        assert_eq!(open_calls.get(), 0);
+    }
+
+    #[test]
+    fn go_allows_reopen_when_item_already_in_progress() {
+        let items = vec![
+            make_item(1, "inprogress.rs", State::InProgress),
+            make_item(2, "todo.rs", State::Todo),
+        ];
+        let (workspace, _) = create_workspace_with_items(&items);
+        let root = workspace.path();
+        fs::write(root.join("inprogress.rs"), "current").unwrap();
+
+        let before = state_snapshot(root);
+        let open_calls = Cell::new(0usize);
+        let capture_calls = Cell::new(0usize);
+        let mark_calls = Cell::new(0usize);
+
+        plumb_go_from_cwd_with_ops(
+            root,
+            "1".to_string(),
+            |_| {
+                open_calls.set(open_calls.get() + 1);
+                Ok(())
+            },
+            |_, _, _, _| {
+                capture_calls.set(capture_calls.get() + 1);
+                Ok(())
+            },
+            |_, _, _| {
+                mark_calls.set(mark_calls.get() + 1);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        let after = state_snapshot(root);
+        assert_eq!(open_calls.get(), 1);
+        assert_eq!(capture_calls.get(), 0);
+        assert_eq!(mark_calls.get(), 0);
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn go_rejects_directory_target_when_not_in_queue() {
+        let items = vec![make_item(1, "tracked.rs", State::Todo)];
+        let (workspace, _) = create_workspace_with_items(&items);
+        let root = workspace.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        let target = root.join("src").to_string_lossy().to_string();
+
+        let err = plumb_go_from_cwd_with_ops(
+            root,
+            target,
+            |_| Ok(()),
+            |_, _, _, _| Ok(()),
+            |_, _, _| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, GoError::FileNotInQueue(msg) if msg.contains("src")));
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn open_in_editor_uses_EDITOR_env_when_set() {
+        let mut selected_editor = String::new();
+        open_in_editor_with(
+            Path::new("file.rs"),
+            || Some("nvim".to_string()),
+            |editor, _| {
+                selected_editor = editor.to_string();
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(selected_editor, "nvim");
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn open_in_editor_defaults_to_vim_when_EDITOR_missing() {
+        let mut selected_editor = String::new();
+        open_in_editor_with(
+            Path::new("file.rs"),
+            || None,
+            |editor, _| {
+                selected_editor = editor.to_string();
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(selected_editor, "vim");
+    }
+
+    #[test]
+    fn baseline_capture_errors_when_file_missing() {
+        let (workspace, session_id) = create_workspace_with_items(&[]);
+        let root = workspace.path();
+        let baseline_path = root
+            .join(".plumb/sessions")
+            .join(&session_id)
+            .join("snapshots/1.baseline");
+
+        let err = capture_baseline(root, &session_id, 1, "missing.rs").unwrap_err();
+        assert!(
+            matches!(err, GoError::BaselineCaptureError(msg) if msg.contains("file does not exist"))
+        );
+        assert!(!baseline_path.exists());
+    }
+
+    #[test]
+    fn baseline_capture_errors_when_path_is_directory() {
+        let (workspace, session_id) = create_workspace_with_items(&[]);
+        let root = workspace.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        let baseline_path = root
+            .join(".plumb/sessions")
+            .join(&session_id)
+            .join("snapshots/2.baseline");
+
+        let err = capture_baseline(root, &session_id, 2, "src").unwrap_err();
+        assert!(matches!(err, GoError::BaselineCaptureError(msg) if msg.contains("folder")));
+        assert!(!baseline_path.exists());
+    }
+
+    #[test]
+    fn mark_item_in_progress_updates_only_target_item_and_persists() {
+        let items = vec![
+            make_item(1, "a.rs", State::Todo),
+            make_item(2, "b.rs", State::Todo),
+            make_item(3, "c.rs", State::Done),
+        ];
+        let (workspace, session_id) = create_workspace_with_items(&items);
+        let root = workspace.path();
+
+        mark_item_in_progress(root, &session_id, 2).unwrap();
+
+        let items = load_items(root).unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].state, State::Todo);
+        assert_eq!(items[1].state, State::InProgress);
+        assert_eq!(items[2].state, State::Done);
+    }
+
+    #[test]
+    fn go_only_persists_state_after_successful_baseline_capture() {
+        let items = vec![make_item(1, "a.rs", State::Todo)];
+        let (workspace, _) = create_workspace_with_items(&items);
+        let root = workspace.path();
+        fs::write(root.join("a.rs"), "content").unwrap();
+
+        let mark_calls = Cell::new(0usize);
+        let open_calls = Cell::new(0usize);
+        let err = plumb_go_from_cwd_with_ops(
+            root,
+            "1".to_string(),
+            |_| {
+                open_calls.set(open_calls.get() + 1);
+                Ok(())
+            },
+            |_, _, _, _| {
+                Err(GoError::BaselineCaptureError(
+                    "simulated baseline failure".to_string(),
+                ))
+            },
+            |_, _, _| {
+                mark_calls.set(mark_calls.get() + 1);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, GoError::BaselineCaptureError(msg) if msg.contains("simulated baseline failure"))
+        );
+        assert_eq!(mark_calls.get(), 0);
+        assert_eq!(open_calls.get(), 0);
+        assert_eq!(load_items(root).unwrap()[0].state, State::Todo);
+    }
+
+    #[test]
+    fn go_refuses_second_go_when_any_item_already_in_progress() {
+        let items = vec![
+            make_item(1, "a.rs", State::InProgress),
+            make_item(2, "b.rs", State::Todo),
+        ];
+
+        let err = go_plan(&items, 2, "b.rs", State::Todo, || Ok(())).unwrap_err();
+        assert!(matches!(err, GoError::AlreadyInProgress(msg) if msg.contains("[1] a.rs")));
+    }
+
+    #[test]
+    fn go_plan_returns_no_mutation_on_pre_baseline_failures() {
+        let items = vec![make_item(1, "a.rs", State::Todo)];
+        let before: Vec<(usize, String, State)> = items
+            .iter()
+            .map(|item| (item.id, item.rel_path.clone(), item.state.clone()))
+            .collect();
+
+        for message in [
+            "file does not exist: a.rs",
+            "failed to read file: permission denied",
+        ] {
+            let err = go_plan(&items, 1, "a.rs", State::Todo, || {
+                Err(GoError::BaselineCaptureError(message.to_string()))
+            })
+            .unwrap_err();
+            assert!(matches!(err, GoError::BaselineCaptureError(err_msg) if err_msg == message));
+
+            let after: Vec<(usize, String, State)> = items
+                .iter()
+                .map(|item| (item.id, item.rel_path.clone(), item.state.clone()))
+                .collect();
+            assert_eq!(after, before);
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn go_plan_returns_no_mutation_on_unreadable_file_check() {
+        let items = vec![make_item(1, "private.rs", State::Todo)];
+        let (workspace, _) = create_workspace_with_items(&items);
+        let root = workspace.path();
+        let private_path = root.join("private.rs");
+        fs::write(&private_path, "top secret").unwrap();
+
+        let mut perms = fs::metadata(&private_path).unwrap().permissions();
+        perms.set_mode(0o000);
+        fs::set_permissions(&private_path, perms).unwrap();
+
+        let before = state_snapshot(root);
+        let err = go_plan(&items, 1, "private.rs", State::Todo, || {
+            ensure_baseline_source_ready(root, "private.rs")
+        })
+        .unwrap_err();
+        assert!(matches!(err, GoError::BaselineCaptureError(_)));
+
+        let mut restore = fs::metadata(&private_path).unwrap().permissions();
+        restore.set_mode(0o644);
+        fs::set_permissions(&private_path, restore).unwrap();
+
+        let after = state_snapshot(root);
+        assert_eq!(after, before);
+    }
+}

--- a/plumb/src/commands/mod.rs
+++ b/plumb/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod go;
 pub mod rm;
 pub mod start;
 pub mod status;

--- a/plumb/src/commands/rm.rs
+++ b/plumb/src/commands/rm.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::{
-    fs::normalize_rel_path,
+    helpers::{HelperError, resolve_item},
     store::items::{Item, State, active_session_id, load_items, save_items, session_dir},
+    workspace::resolve_workspace_root,
 };
 
 #[derive(Debug, Error)]
@@ -18,13 +19,14 @@ pub enum RmError {
     #[error("{0}")]
     FileNotInQueue(String),
     #[error("{0}")]
+    HelperError(#[from] HelperError),
+    #[error("{0}")]
     UnknownError(String),
 }
 
 pub fn plumb_rm(target: String) -> Result<(), RmError> {
     let cwd = std::env::current_dir().map_err(|e| RmError::UnknownError(e.to_string()))?;
-    let root = crate::workspace::resolve_workspace_root(&cwd)
-        .map_err(|e| RmError::UnknownError(e.to_string()))?;
+    let root = resolve_workspace_root(&cwd).map_err(|e| RmError::UnknownError(e.to_string()))?;
 
     let session_id = active_session_id(&root).map_err(|_| {
         RmError::NoActiveSession(
@@ -50,31 +52,6 @@ pub fn plumb_rm(target: String) -> Result<(), RmError> {
     println!("Removed: [{}] {}", item_id, normalized_path);
 
     Ok(())
-}
-
-fn resolve_item(
-    root: &Path,
-    items: &[Item],
-    target: &str,
-) -> Result<(usize, String, State), RmError> {
-    if target.chars().all(|c| c.is_ascii_digit())
-        && let Ok(id) = target.parse::<usize>()
-        && let Some(item) = items.iter().find(|item| item.id == id)
-    {
-        return Ok((item.id, item.rel_path.clone(), item.state.clone()));
-    }
-
-    let normalized_path = normalize_rel_path(root, Path::new(target))
-        .map_err(|e| RmError::UnknownError(e.to_string()))?;
-
-    let item = items
-        .iter()
-        .find(|item| item.rel_path == normalized_path)
-        .ok_or_else(|| {
-            RmError::FileNotInQueue(format!("file not in queue: {}", normalized_path))
-        })?;
-
-    Ok((item.id, normalized_path, item.state.clone()))
 }
 
 fn remove_item(items: &[Item], item_id: usize) -> Result<Vec<Item>, RmError> {

--- a/plumb/src/commands/start.rs
+++ b/plumb/src/commands/start.rs
@@ -6,15 +6,15 @@ use crate::workspace::{
 };
 
 #[derive(Debug, Error)]
-pub enum PlumbStartError {
+pub enum StartError {
     #[error("{0}")]
     WorkspaceError(#[from] WorkspaceError),
     #[error("{0}")]
     UnknownError(String),
 }
 
-pub fn plumb_start(name: Option<String>) -> Result<(), PlumbStartError> {
-    let cwd = std::env::current_dir().map_err(|e| PlumbStartError::UnknownError(e.to_string()))?;
+pub fn plumb_start(name: Option<String>) -> Result<(), StartError> {
+    let cwd = std::env::current_dir().map_err(|e| StartError::UnknownError(e.to_string()))?;
 
     let root = resolve_workspace_root(&cwd)?;
     ensure_plumb_dir(&root)?;

--- a/plumb/src/error.rs
+++ b/plumb/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use crate::{
-    commands::{add::AddError, rm::RmError, start::PlumbStartError, status::StatusError},
+    commands::{add::AddError, go::GoError, rm::RmError, start::StartError, status::StatusError},
     fs::InputError,
     store::items::StoreError,
     workspace::WorkspaceError,
@@ -9,6 +9,8 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum PlumbError {
+    #[error("go error: {0}")]
+    GoError(#[from] GoError),
     #[error("rm error: {0}")]
     RmError(#[from] RmError),
     #[error("status error: {0}")]
@@ -18,7 +20,7 @@ pub enum PlumbError {
     #[error("store error: {0}")]
     StoreError(#[from] StoreError),
     #[error("start error: {0}")]
-    StartError(#[from] PlumbStartError),
+    StartError(#[from] StartError),
     #[error("workspace error: {0}")]
     WorkspaceError(#[from] WorkspaceError),
     #[error("input error: {0}")]

--- a/plumb/src/helpers.rs
+++ b/plumb/src/helpers.rs
@@ -1,0 +1,102 @@
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::{
+    fs::normalize_rel_path,
+    store::items::{Item, State},
+};
+
+#[derive(Debug, Error)]
+pub enum HelperError {
+    #[error("{0}")]
+    PathNormalizationError(String),
+    #[error("{0}")]
+    FileNotInQueue(String),
+    #[error("{0}")]
+    UnknownError(String),
+}
+
+pub fn resolve_item(
+    root: &Path,
+    items: &[Item],
+    target: &str,
+) -> Result<(usize, String, State), HelperError> {
+    if target.chars().all(|c| c.is_ascii_digit())
+        && let Ok(id) = target.parse::<usize>()
+        && let Some(item) = items.iter().find(|item| item.id == id)
+    {
+        return Ok((item.id, item.rel_path.clone(), item.state.clone()));
+    }
+
+    let normalized_path = normalize_rel_path(root, Path::new(target))
+        .map_err(|e| HelperError::PathNormalizationError(e.to_string()))?;
+
+    let item = items
+        .iter()
+        .find(|item| item.rel_path == normalized_path)
+        .ok_or_else(|| {
+            HelperError::FileNotInQueue(format!("file not in queue: {}", normalized_path))
+        })?;
+
+    Ok((item.id, normalized_path, item.state.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_item(id: usize, rel_path: &str, state: State) -> Item {
+        Item {
+            id,
+            rel_path: rel_path.to_string(),
+            state,
+        }
+    }
+
+    #[test]
+    fn resolve_item_by_id_returns_id_path_state() {
+        let root = TempDir::new().unwrap();
+        let items = vec![make_item(1, "src/a.rs", State::Todo)];
+
+        let result = resolve_item(root.path(), &items, "1").unwrap();
+        assert_eq!(result.0, 1);
+        assert_eq!(result.1, "src/a.rs");
+        assert_eq!(result.2, State::Todo);
+    }
+
+    #[test]
+    fn resolve_item_by_path_normalizes_and_finds_item() {
+        let root = TempDir::new().unwrap();
+        let items = vec![make_item(3, "src/a.rs", State::InProgress)];
+        let absolute_target = root.path().join("src/./a.rs");
+
+        let result = resolve_item(root.path(), &items, &absolute_target.to_string_lossy()).unwrap();
+        assert_eq!(result.0, 3);
+        assert_eq!(result.1, "src/a.rs");
+        assert_eq!(result.2, State::InProgress);
+    }
+
+    #[test]
+    fn resolve_item_returns_file_not_in_queue_for_unknown_target() {
+        let root = TempDir::new().unwrap();
+        let items = vec![make_item(1, "src/a.rs", State::Todo)];
+        let unknown_target = root.path().join("src/b.rs");
+
+        let err = resolve_item(root.path(), &items, &unknown_target.to_string_lossy()).unwrap_err();
+        assert!(matches!(err, HelperError::FileNotInQueue(msg) if msg.contains("src/b.rs")));
+    }
+
+    #[test]
+    fn resolve_item_returns_path_normalization_error_on_bad_path() {
+        let root = TempDir::new().unwrap();
+        let items = vec![make_item(1, "src/a.rs", State::Todo)];
+        let bad_target = root.path().parent().unwrap().join("outside.rs");
+
+        let err = resolve_item(root.path(), &items, &bad_target.to_string_lossy()).unwrap_err();
+        assert!(
+            matches!(err, HelperError::PathNormalizationError(msg) if msg.contains("outside.rs"))
+        );
+    }
+}

--- a/plumb/src/lib.rs
+++ b/plumb/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cli;
 pub mod commands;
 pub mod error;
 pub mod fs;
+pub mod helpers;
 pub mod store;
 pub mod workspace;

--- a/plumb/tests/integration_go.rs
+++ b/plumb/tests/integration_go.rs
@@ -1,0 +1,342 @@
+use assert_cmd::cargo;
+use assert_cmd::prelude::*;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use strata::decode::decode;
+use strata::value::Value;
+
+fn plumb_binary() -> Command {
+    Command::new(cargo::cargo_bin!("plumb"))
+}
+
+fn get_session_id(root: &Path) -> String {
+    fs::read_to_string(root.join(".plumb/active"))
+        .unwrap()
+        .trim()
+        .to_string()
+}
+
+fn read_items(root: &Path) -> Value {
+    let session_id = get_session_id(root);
+    let items_path = root
+        .join(".plumb")
+        .join("sessions")
+        .join(&session_id)
+        .join("items.scb");
+    let data = fs::read(&items_path).unwrap();
+    decode(&data).unwrap()
+}
+
+fn go_with_true_editor(root: &Path, target: &str) -> Output {
+    plumb_binary()
+        .current_dir(root)
+        .env("EDITOR", "true")
+        .arg("go")
+        .arg(target)
+        .output()
+        .unwrap()
+}
+
+fn item_state(root: &Path, rel_path: &str) -> String {
+    let Value::List(items) = read_items(root) else {
+        panic!("items should be a list");
+    };
+
+    for item in items {
+        let Value::Map(map) = item else {
+            panic!("item should be a map");
+        };
+
+        let Value::String(path) = map.get("rel_path").unwrap() else {
+            panic!("rel_path should be string");
+        };
+        if path == rel_path {
+            let Value::String(state) = map.get("state").unwrap() else {
+                panic!("state should be string");
+            };
+            return state.clone();
+        }
+    }
+
+    panic!("item not found: {}", rel_path);
+}
+
+fn baseline_path(root: &Path, session_id: &str, item_id: usize) -> PathBuf {
+    root.join(".plumb")
+        .join("sessions")
+        .join(session_id)
+        .join("snapshots")
+        .join(format!("{}.baseline", item_id))
+}
+
+#[test]
+fn go_baseline_capture_matches_bytes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+
+    let source_path = root.join("a.rs");
+    fs::write(&source_path, b"fn main() {\n    println!(\"hello\");\n}\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("a.rs")
+        .assert()
+        .success();
+
+    let output = go_with_true_editor(root, "1");
+    assert!(
+        output.status.success(),
+        "go should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let session_id = get_session_id(root);
+    let baseline = fs::read(baseline_path(root, &session_id, 1)).unwrap();
+    let source = fs::read(source_path).unwrap();
+    assert_eq!(baseline, source);
+}
+
+#[test]
+fn go_marks_item_in_progress_and_persists() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    fs::write(root.join("tracked.rs"), "let a = 1;\n").unwrap();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("tracked.rs")
+        .assert()
+        .success();
+
+    let output = go_with_true_editor(root, "1");
+    assert!(
+        output.status.success(),
+        "go should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(item_state(root, "tracked.rs"), "in_progress");
+}
+
+#[test]
+fn go_refuses_second_go_when_one_in_progress_and_leaves_other_todo() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    fs::write(root.join("a.rs"), "a").unwrap();
+    fs::write(root.join("b.rs"), "b").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("a.rs")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("b.rs")
+        .assert()
+        .success();
+
+    let first_go = go_with_true_editor(root, "1");
+    assert!(
+        first_go.status.success(),
+        "first go should succeed: {}",
+        String::from_utf8_lossy(&first_go.stderr)
+    );
+
+    let second_go = go_with_true_editor(root, "2");
+    assert!(!second_go.status.success(), "second go should fail");
+
+    let stderr = String::from_utf8_lossy(&second_go.stderr);
+    assert!(
+        stderr.to_lowercase().contains("already in progress"),
+        "expected in-progress error, got: {}",
+        stderr
+    );
+
+    assert_eq!(item_state(root, "a.rs"), "in_progress");
+    assert_eq!(item_state(root, "b.rs"), "todo");
+}
+
+#[test]
+fn go_missing_file_fails_leaves_todo_and_no_baseline_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    fs::write(root.join("a.rs"), "a").unwrap();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("a.rs")
+        .assert()
+        .success();
+
+    fs::remove_file(root.join("a.rs")).unwrap();
+    let output = go_with_true_editor(root, "1");
+    assert!(
+        !output.status.success(),
+        "go should fail when file is missing"
+    );
+
+    assert_eq!(item_state(root, "a.rs"), "todo");
+    let session_id = get_session_id(root);
+    assert!(!baseline_path(root, &session_id, 1).exists());
+}
+
+#[test]
+#[cfg(unix)]
+fn go_unreadable_file_fails_leaves_todo_and_no_baseline_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    let source_path = root.join("secret.rs");
+    fs::write(&source_path, "secret").unwrap();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("secret.rs")
+        .assert()
+        .success();
+
+    let mut perms = fs::metadata(&source_path).unwrap().permissions();
+    perms.set_mode(0o000);
+    fs::set_permissions(&source_path, perms).unwrap();
+
+    let output = go_with_true_editor(root, "1");
+
+    let mut restore = fs::metadata(&source_path).unwrap().permissions();
+    restore.set_mode(0o644);
+    fs::set_permissions(&source_path, restore).unwrap();
+
+    assert!(
+        !output.status.success(),
+        "go should fail for unreadable files"
+    );
+    assert_eq!(item_state(root, "secret.rs"), "todo");
+
+    let session_id = get_session_id(root);
+    assert!(!baseline_path(root, &session_id, 1).exists());
+}
+
+#[test]
+fn go_with_editor_env_runs_noninteractive_editor() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    fs::write(root.join("a.rs"), "hello").unwrap();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("a.rs")
+        .assert()
+        .success();
+
+    let output = go_with_true_editor(root, "1");
+    assert!(
+        output.status.success(),
+        "go should succeed with EDITOR=true: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn go_item_already_in_progress_reopens_editor_and_does_not_create_new_baseline() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    let source_path = root.join("a.rs");
+    fs::write(&source_path, "first contents").unwrap();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("a.rs")
+        .assert()
+        .success();
+
+    let first_go = go_with_true_editor(root, "1");
+    assert!(
+        first_go.status.success(),
+        "first go should succeed: {}",
+        String::from_utf8_lossy(&first_go.stderr)
+    );
+
+    let session_id = get_session_id(root);
+    let baseline = baseline_path(root, &session_id, 1);
+    let before = fs::read(&baseline).unwrap();
+
+    fs::write(&source_path, "second contents").unwrap();
+    let second_go = go_with_true_editor(root, "1");
+    assert!(
+        second_go.status.success(),
+        "second go should reopen and succeed: {}",
+        String::from_utf8_lossy(&second_go.stderr)
+    );
+
+    let after = fs::read(&baseline).unwrap();
+    assert_eq!(before, after, "baseline should not be recaptured");
+}
+
+#[test]
+fn go_without_active_session_fails_with_clear_message() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::write(root.join("a.rs"), "hello").unwrap();
+    let output = go_with_true_editor(root, "1");
+
+    assert!(!output.status.success(), "go should fail without a session");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no active session found"),
+        "expected no-active-session message, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("plumb start"),
+        "expected guidance to run plumb start, got: {}",
+        stderr
+    );
+}

--- a/plumb/tests/integration_rm.rs
+++ b/plumb/tests/integration_rm.rs
@@ -279,3 +279,54 @@ fn rm_refuses_to_remove_in_progress_item() {
     };
     assert_eq!(items.len(), 1, "item should still exist after failed rm");
 }
+
+#[test]
+fn rm_accepts_id_and_path_via_shared_resolve_item() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "").unwrap();
+    fs::write(root.join("src/b.rs"), "").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.rs")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/b.rs")
+        .assert()
+        .success();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("rm")
+        .arg("1")
+        .assert()
+        .success();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("rm")
+        .arg("src/b.rs")
+        .assert()
+        .success();
+
+    let Value::List(items) = read_items(root) else {
+        panic!("items should be a list");
+    };
+    assert!(
+        items.is_empty(),
+        "both id and path forms should resolve and remove items"
+    );
+}


### PR DESCRIPTION
## Summary
This PR adds the `plumb go` command, letting you jump into a queued file by ID or path, capture a baseline snapshot, mark it `in_progress`, and open it in your editor (using `$EDITOR`, defaulting to `vim`). It also tightens up docs and reduces duplicated CLI resolution logic by introducing a shared `resolve_item` helper.

## Changes
- Added `go <id|file>` CLI command and wired it into `plumb/src/cli.rs`, plus exported the new `commands::go` module.
- Implemented `plumb go` behavior:
  - Resolves target by item ID or normalized path.
  - Enforces the single `in_progress` rule (refuses starting a second item).
  - Captures baseline into `.plumb/sessions/<sid>/snapshots/<item_id>.baseline` using atomic writes.
  - Marks item as `in_progress` only after a successful baseline capture.
  - Opens `$EDITOR` (defaults to `vim`) and supports reopening an already `in_progress` item without recapturing the baseline.
- Added `plumb/src/helpers.rs` with `resolve_item()` and tests; migrated `rm` to use it (removing local duplicate resolution code).
- Updated docs:
  - README command list now includes `rm <id|file>`.
  - `go` docs now describe “opens editor (defaults to vim)” and no longer claim it always opens `vim`.
- Added comprehensive tests:
  - Unit tests for `go` planning, baseline capture checks, and editor selection behavior.
  - New integration test suite for `go`, covering baseline bytes, persistence, missing/unreadable files, single-in-progress enforcement, reopen semantics, and no-active-session messaging.
  - Extended `rm` integration tests to validate both ID and path removal via shared resolver.

Closes #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "go" CLI command to open and work on queued items with automatic baseline capture and progress tracking.

* **Documentation**
  * Updated documentation to clarify that the editor is configurable and defaults to vim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->