### PR TITLE
feat(diff): implement `plumb diff`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ plumb finish
 Plumb tracks files through three states: `todo`, `in_progress`, `done`.
 When you start working on a file (`plumb go`), a baseline snapshot is captured
 and the file opens in vim. When you're done, `plumb diff` shows exactly what
-changed against that baseline. One file at a time, one session at a time.
+changed against that baseline. Keep work focused within one session, while
+supporting multiple `in_progress` items when needed.
 
 ## Commands
 
@@ -28,7 +29,7 @@ add -f <folder>    enqueue all files in a folder (recursive)
 rm <id|file>       removes a file from the queue
 status             show session progress
 go <id|file>       set item in_progress, capture baseline, open vim
-diff [id|file]     diff current file against baseline
+diff [id|file]     diff one item, or all in_progress items if omitted
 done [id|file]     mark in_progress item as done
 restore [id|file]  revert file to baseline (confirms before overwriting)
 next               print next todo item

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -69,7 +69,7 @@ See a complete walkthrough: [Typical flow](./examples/typical-flow.md).
 | [plumb rm](./commands/rm.md)         | Remove an item from the queue.                                |
 | [plumb status](./commands/status.md) | Show session progress and the current in-progress item.       |
 | [plumb go](./commands/go.md)         | Start working on a specific item; captures baseline snapshot and opens vim. |
-| [plumb diff](./commands/diff.md)     | Diff current file contents against the go-time baseline.      |
+| [plumb diff](./commands/diff.md)     | Diff a target item, or all `in_progress` items when target is omitted. |
 | [plumb done](./commands/done.md)         | Mark the in-progress item as done.                            |
 | [plumb restore](./commands/restore.md)   | Restore a file to its baseline snapshot.                      |
 | [plumb next](./commands/next.md)         | Print the next todo item without changing state.              |
@@ -84,7 +84,7 @@ See a complete walkthrough: [Typical flow](./examples/typical-flow.md).
 - **`plumb rm <id|file>`** -- Removes an item from the session queue. Cannot remove an `in_progress` item.
 - **`plumb status`** -- Prints counts of todo / in-progress / done items and the currently in-progress file, if any.
 - **`plumb go <id|file>`** -- Sets one `todo` item to `in_progress`, captures a baseline snapshot of that file's current contents, and opens the file in vim.
-- **`plumb diff [id|file]`** -- Shows the unified diff between the file's current contents on disk and its go-time baseline snapshot.
+- **`plumb diff [id|file]`** -- Shows the unified diff between go-time baseline and current contents. With no argument, diffs all `in_progress` items (no-op if none).
 - **`plumb done [id|file]`** -- Moves the current `in_progress` item to `done`.
 - **`plumb restore [id|file]`** -- Overwrites the file on disk with its go-time baseline snapshot. Prompts for confirmation before proceeding.
 - **`plumb next`** -- Prints the next `todo` item (lowest ID) without changing any state.

--- a/docs/commands/diff.md
+++ b/docs/commands/diff.md
@@ -14,13 +14,16 @@ Produces a unified diff between the **baseline snapshot** (captured at
 `plumb go` time) and the file's **current contents on disk**. This shows
 exactly what you changed during your refactoring pass.
 
-By default (no arguments), it diffs the currently `in_progress` item.
+If you provide a target (`id` or `file`), Plumb diffs that specific item.
+
+If you omit the target, Plumb diffs **all items currently in `in_progress`**.
+If none are `in_progress`, the command succeeds and prints nothing.
 
 ## Arguments
 
 | Argument       | Required | Description                                                                                                                        |
 | -------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `id` or `file` | No       | The item to diff. Defaults to the current `in_progress` item. Accepts an integer ID or a file path relative to the workspace root. |
+| `id` or `file` | No       | The item to diff. If omitted, Plumb diffs all `in_progress` items. Accepts an integer ID or a file path relative to the workspace root. |
 
 ## Options
 
@@ -37,17 +40,17 @@ merge, and no git involvement.
 
 ## Examples
 
-Diff the current in-progress item (most common):
+Diff all currently in-progress items:
 
 ```bash
 plumb diff
 # --- baseline: src/auth/guard.rs
 # +++ current:  src/auth/guard.rs
 # @@ -10,7 +10,7 @@
-#  fn check_auth(req: &Request) -> bool {
-# -    req.headers.contains("Authorization")
-# +    req.headers.get("Authorization").is_some_and(|v| !v.is_empty())
-#  }
+# ...
+# --- baseline: src/auth/session.rs
+# +++ current:  src/auth/session.rs
+# ...
 ```
 
 Diff a specific item by ID:
@@ -66,10 +69,11 @@ plumb diff src/auth/session.rs
 
 | Scenario                                      | Behavior                                                        |
 | --------------------------------------------- | --------------------------------------------------------------- |
-| No argument and no item `in_progress`         | Error: no in-progress item to diff.                             |
+| No argument and no item `in_progress`         | Success with empty output (no-op).                              |
 | Specified item is `todo` (no baseline exists) | Error: no baseline snapshot. Run `plumb go` first.              |
 | Baseline snapshot file is missing on disk     | Error: baseline not found. This should not occur in normal use. |
 | File deleted after go-time                    | Diff shows all lines removed (file treated as empty).           |
+| Baseline or current file is non-UTF-8 bytes   | Prints `Binary files differ: <path>` for that item.             |
 | File unchanged since go-time                  | Empty diff (no output).                                         |
 
 ## Notes

--- a/docs/concepts/snapshots.md
+++ b/docs/concepts/snapshots.md
@@ -56,6 +56,7 @@ core functionality.
 | File is unreadable (permissions) | `plumb go` fails with an error. The item stays `todo`. |
 | Baseline missing when running `plumb diff` | `plumb diff` fails with an error. This should not happen in normal use. |
 | File deleted after go-time | `plumb diff` reports the file as deleted (all lines removed). |
+| Baseline/current is non-UTF-8 bytes | `plumb diff` prints `Binary files differ: <path>`. |
 
 ## See also
 

--- a/plumb/Cargo.lock
+++ b/plumb/Cargo.lock
@@ -339,6 +339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +448,7 @@ dependencies = [
  "assert_cmd",
  "atomicwrites",
  "clap",
+ "imara-diff",
  "predicates",
  "rand",
  "strata-rs",

--- a/plumb/Cargo.toml
+++ b/plumb/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 anyhow = "1.0.102"
 atomicwrites = "0.4.4"
 clap = { version = "4.5.60", features = ["derive"] }
+imara-diff = "0.1"
 rand = "0.10.0"
 strata-rs = "0.4.3"
 thiserror = "2.0.18"

--- a/plumb/src/cli.rs
+++ b/plumb/src/cli.rs
@@ -2,7 +2,8 @@ use clap::{Parser, Subcommand};
 
 use crate::{
     commands::{
-        add::plumb_add, go::plumb_go, rm::plumb_rm, start::plumb_start, status::plumb_status,
+        add::plumb_add, diff::plumb_diff, go::plumb_go, rm::plumb_rm, start::plumb_start,
+        status::plumb_status,
     },
     error::PlumbError,
 };
@@ -41,7 +42,7 @@ pub enum Commands {
         /// Path to the file to add.
         /// Example: "src/auth/guards.rs"
         #[arg(verbatim_doc_comment)]
-        file: String,
+        target: String,
     },
 
     /// Remove a file from the current session's queue.
@@ -49,7 +50,7 @@ pub enum Commands {
         /// File path or item ID to remove.
         /// Example: "src/auth/guards.rs" or 3
         #[arg(verbatim_doc_comment)]
-        file: String,
+        target: String,
     },
 
     /// Prints the current session's queue of files to be refactored.
@@ -61,7 +62,17 @@ pub enum Commands {
         /// File path or item ID of the file to refactor.
         /// Example: "src/auth/guards.rs"
         #[arg(verbatim_doc_comment)]
-        file: String,
+        target: String,
+    },
+
+    /// Compares the current version of the file with the baseline, and
+    /// prints the diff to the terminal.
+    Diff {
+        /// File path or item ID of the file to diff.
+        /// Omit to diff all items currently `In Progress`.
+        /// Example: "src/auth/guards.rs"
+        #[arg(verbatim_doc_comment)]
+        target: Option<String>,
     },
 }
 
@@ -70,10 +81,11 @@ pub fn run() -> Result<(), PlumbError> {
 
     match cli.command {
         Commands::Start { name } => plumb_start(name)?,
-        Commands::Add { folder, file } => plumb_add(file, folder)?,
+        Commands::Add { folder, target } => plumb_add(target, folder)?,
         Commands::Status {} => plumb_status()?,
-        Commands::Rm { file } => plumb_rm(file)?,
-        Commands::Go { file } => plumb_go(file)?,
+        Commands::Rm { target } => plumb_rm(target)?,
+        Commands::Go { target } => plumb_go(target)?,
+        Commands::Diff { target } => plumb_diff(target)?,
     }
 
     Ok(())

--- a/plumb/src/commands/diff.rs
+++ b/plumb/src/commands/diff.rs
@@ -1,0 +1,315 @@
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::{
+    diff::render_baseline_diff,
+    helpers::{resolve_item, HelperError},
+    store::items::{active_session_id, load_items, Item, State, StoreError},
+    workspace::resolve_workspace_root,
+};
+
+#[derive(Error, Debug)]
+pub enum DiffError {
+    #[error("{0}")]
+    FileReadError(String),
+    #[error("{0}")]
+    FileWriteError(String),
+    #[error("{0}")]
+    DiffComputationError(String),
+    #[error("{0}")]
+    NoActiveSession(String),
+    #[error("{0}")]
+    FileNotInQueue(String),
+    #[error("{0}")]
+    HelperError(#[from] HelperError),
+    #[error("{0}")]
+    StoreError(#[from] StoreError),
+    #[error("{0}")]
+    UnknownError(String),
+}
+
+pub fn plumb_diff(target: Option<String>) -> Result<(), DiffError> {
+    let cwd = std::env::current_dir().map_err(|e| DiffError::UnknownError(e.to_string()))?;
+    let root = resolve_workspace_root(&cwd).map_err(|e| DiffError::UnknownError(e.to_string()))?;
+
+    let session_id = active_session_id(&root).map_err(|_| {
+        DiffError::NoActiveSession(
+            "no active session found, use `plumb start` to start a session".to_string(),
+        )
+    })?;
+
+    let items = load_items(&root)?;
+
+    match target {
+        Some(t) => plumb_diff_target(t, &root, &session_id, &items),
+        None => plumb_diff_all(&root, &session_id, &items),
+    }
+}
+
+fn plumb_diff_target(
+    target: String,
+    root: &Path,
+    session_id: &str,
+    items: &[Item],
+) -> Result<(), DiffError> {
+    let (item_id, normalized_path, state) =
+        resolve_item(root, items, &target).map_err(|e| match e {
+            HelperError::FileNotInQueue(msg) => DiffError::FileNotInQueue(msg),
+            other => DiffError::HelperError(other),
+        })?;
+
+    if state == State::Todo {
+        return Err(DiffError::FileReadError(
+            "no baseline snapshot. Run `plumb go` first".to_string(),
+        ));
+    }
+
+    let baseline_path = baseline_path(root, session_id, item_id);
+    let baseline_bytes = load_baseline_bytes(&baseline_path)?;
+
+    let current_path = root.join(&normalized_path);
+    let current_bytes = load_current_bytes(&current_path)?;
+
+    let diff = compute_display_diff(&normalized_path, &baseline_bytes, &current_bytes)?;
+    if !diff.is_empty() {
+        print!("{diff}");
+    }
+
+    Ok(())
+}
+
+fn plumb_diff_all(root: &Path, session_id: &str, items: &[Item]) -> Result<(), DiffError> {
+    plumb_diff_all_with(root, session_id, items, plumb_diff_target)
+}
+
+fn plumb_diff_all_with<F>(
+    root: &Path,
+    session_id: &str,
+    items: &[Item],
+    mut diff_target_fn: F,
+) -> Result<(), DiffError>
+where
+    F: FnMut(String, &Path, &str, &[Item]) -> Result<(), DiffError>,
+{
+    for (_, rel_path) in collect_in_progress_items(items) {
+        diff_target_fn(rel_path, root, session_id, items)?;
+    }
+
+    Ok(())
+}
+
+fn collect_in_progress_items(items: &[Item]) -> Vec<(usize, String)> {
+    items
+        .iter()
+        .filter(|item| item.state == State::InProgress)
+        .map(|item| (item.id, item.rel_path.clone()))
+        .collect()
+}
+
+fn baseline_path(root: &Path, session_id: &str, item_id: usize) -> PathBuf {
+    root.join(".plumb")
+        .join("sessions")
+        .join(session_id)
+        .join("snapshots")
+        .join(format!("{}.baseline", item_id))
+}
+
+fn load_baseline_bytes(path: &Path) -> Result<Vec<u8>, DiffError> {
+    std::fs::read(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            DiffError::FileReadError(
+                "baseline snapshot not found on disk (this should not happen in normal use)"
+                    .to_string(),
+            )
+        } else {
+            DiffError::FileReadError(format!("failed to read baseline snapshot: {e}"))
+        }
+    })
+}
+
+fn load_current_bytes(path: &Path) -> Result<Vec<u8>, DiffError> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(bytes),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(DiffError::FileReadError(format!(
+            "failed to read current file: {e}"
+        ))),
+    }
+}
+
+fn compute_display_diff(
+    path_label: &str,
+    baseline: &[u8],
+    current: &[u8],
+) -> Result<String, DiffError> {
+    Ok(render_baseline_diff(path_label, baseline, current))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::items::save_items;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn make_item(id: usize, rel_path: &str, state: State) -> Item {
+        Item {
+            id,
+            rel_path: rel_path.to_string(),
+            state,
+        }
+    }
+
+    fn create_workspace_with_active_session(items: &[Item]) -> (TempDir, String) {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let session_id = "deadbeef".to_string();
+
+        std::fs::create_dir_all(
+            root.join(".plumb")
+                .join("sessions")
+                .join(&session_id)
+                .join("snapshots"),
+        )
+        .unwrap();
+        std::fs::write(root.join(".plumb").join("active"), &session_id).unwrap();
+        save_items(root, &session_id, items).unwrap();
+
+        (temp_dir, session_id)
+    }
+
+    #[test]
+    fn load_current_bytes_missing_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let bytes = load_current_bytes(&tmp.path().join("missing.txt")).unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_current_bytes_other_error_is_error() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("unreadable.txt");
+        std::fs::write(&path, "secret").unwrap();
+
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o000);
+        std::fs::set_permissions(&path, perms).unwrap();
+
+        let result = load_current_bytes(&path);
+
+        let mut restore = std::fs::metadata(&path).unwrap().permissions();
+        restore.set_mode(0o644);
+        std::fs::set_permissions(&path, restore).unwrap();
+
+        assert!(matches!(result, Err(DiffError::FileReadError(_))));
+    }
+
+    #[test]
+    fn diff_target_errors_when_item_state_todo() {
+        let items = vec![make_item(1, "src/a.txt", State::Todo)];
+        let tmp = TempDir::new().unwrap();
+
+        let err = plumb_diff_target("1".to_string(), tmp.path(), "deadbeef", &items).unwrap_err();
+
+        assert!(
+            matches!(err, DiffError::FileReadError(msg) if msg.contains("Run `plumb go` first"))
+        );
+    }
+
+    #[test]
+    fn diff_target_errors_when_baseline_missing_on_disk_even_if_state_in_progress() {
+        let items = vec![make_item(1, "src/a.txt", State::InProgress)];
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/a.txt"), "current").unwrap();
+
+        let err = plumb_diff_target("1".to_string(), tmp.path(), "deadbeef", &items).unwrap_err();
+        assert!(
+            matches!(err, DiffError::FileReadError(msg) if msg.contains("baseline snapshot not found"))
+        );
+    }
+
+    #[test]
+    fn baseline_path_points_to_sessions_sid_snapshots_id_baseline() {
+        let root = Path::new("/tmp/workspace");
+        let path = baseline_path(root, "a1b2c3d4", 42);
+        let expected = root
+            .join(".plumb")
+            .join("sessions")
+            .join("a1b2c3d4")
+            .join("snapshots")
+            .join("42.baseline");
+        assert_eq!(path, expected);
+    }
+
+    #[test]
+    fn diff_all_only_runs_for_in_progress_items() {
+        let items = vec![
+            make_item(1, "todo.txt", State::Todo),
+            make_item(2, "in_a.txt", State::InProgress),
+            make_item(3, "done.txt", State::Done),
+            make_item(4, "in_b.txt", State::InProgress),
+        ];
+        let mut seen_targets = Vec::new();
+
+        plumb_diff_all_with(Path::new("/tmp"), "deadbeef", &items, |target, _, _, _| {
+            seen_targets.push(target);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            seen_targets,
+            vec!["in_a.txt".to_string(), "in_b.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn diff_all_no_in_progress_is_noop_and_success() {
+        let items = vec![
+            make_item(1, "todo.txt", State::Todo),
+            make_item(2, "done.txt", State::Done),
+        ];
+        let mut calls = 0usize;
+
+        plumb_diff_all_with(Path::new("/tmp"), "deadbeef", &items, |_, _, _, _| {
+            calls += 1;
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(calls, 0);
+    }
+
+    #[test]
+    fn collect_in_progress_items_returns_ids_and_paths() {
+        let items = vec![
+            make_item(10, "a.txt", State::Todo),
+            make_item(11, "b.txt", State::InProgress),
+            make_item(12, "c.txt", State::InProgress),
+        ];
+
+        let in_progress = collect_in_progress_items(&items);
+        assert_eq!(
+            in_progress,
+            vec![(11, "b.txt".to_string()), (12, "c.txt".to_string())]
+        );
+    }
+
+    #[test]
+    fn diff_target_succeeds_for_in_progress_item_with_existing_baseline() {
+        let items = vec![make_item(1, "src/a.txt", State::InProgress)];
+        let (workspace, session_id) = create_workspace_with_active_session(&items);
+        let root = workspace.path();
+
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.txt"), "now").unwrap();
+        std::fs::write(baseline_path(root, &session_id, 1), "before").unwrap();
+
+        let result = plumb_diff_target("1".to_string(), root, &session_id, &items);
+        assert!(result.is_ok());
+    }
+}

--- a/plumb/src/commands/go.rs
+++ b/plumb/src/commands/go.rs
@@ -69,7 +69,7 @@ where
     FCapture: FnMut(&Path, &str, usize, &str) -> Result<(), GoError>,
     FMark: FnMut(&Path, &str, usize) -> Result<(), GoError>,
 {
-    let root = resolve_workspace_root(&cwd).map_err(|e| GoError::UnknownError(e.to_string()))?;
+    let root = resolve_workspace_root(cwd).map_err(|e| GoError::UnknownError(e.to_string()))?;
 
     let session_id = active_session_id(&root).map_err(|_| {
         GoError::NoActiveSession(
@@ -105,7 +105,7 @@ where
 }
 
 fn go_plan<F>(
-    items: &[Item],
+    _items: &[Item],
     item_id: usize,
     normalized_path: &str,
     state: State,
@@ -127,16 +127,6 @@ where
             item_id,
             normalized_path: normalized_path.to_string(),
         });
-    }
-
-    if let Some(in_progress_item) = items
-        .iter()
-        .find(|item| item.state == State::InProgress && item.id != item_id)
-    {
-        return Err(GoError::AlreadyInProgress(format!(
-            "another item is already in progress: [{}] {}",
-            in_progress_item.id, in_progress_item.rel_path
-        )));
     }
 
     pre_baseline_check()?;
@@ -247,6 +237,7 @@ fn capture_baseline(
     Ok(())
 }
 
+// ---- Unit Tests ----
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -489,17 +480,6 @@ mod tests {
         assert_eq!(mark_calls.get(), 0);
         assert_eq!(open_calls.get(), 0);
         assert_eq!(load_items(root).unwrap()[0].state, State::Todo);
-    }
-
-    #[test]
-    fn go_refuses_second_go_when_any_item_already_in_progress() {
-        let items = vec![
-            make_item(1, "a.rs", State::InProgress),
-            make_item(2, "b.rs", State::Todo),
-        ];
-
-        let err = go_plan(&items, 2, "b.rs", State::Todo, || Ok(())).unwrap_err();
-        assert!(matches!(err, GoError::AlreadyInProgress(msg) if msg.contains("[1] a.rs")));
     }
 
     #[test]

--- a/plumb/src/commands/mod.rs
+++ b/plumb/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod diff;
 pub mod go;
 pub mod rm;
 pub mod start;

--- a/plumb/src/diff.rs
+++ b/plumb/src/diff.rs
@@ -1,0 +1,81 @@
+use imara_diff::intern::InternedInput;
+use imara_diff::{Algorithm, UnifiedDiffBuilder, diff as imara_diff};
+
+pub fn render_baseline_diff(path_label: &str, baseline: &[u8], current: &[u8]) -> String {
+    if baseline == current {
+        return String::new();
+    }
+
+    let Ok(baseline_text) = std::str::from_utf8(baseline) else {
+        return format!("Binary files differ: {path_label}\n");
+    };
+    let Ok(current_text) = std::str::from_utf8(current) else {
+        return format!("Binary files differ: {path_label}\n");
+    };
+
+    let input = InternedInput::new(baseline_text, current_text);
+    let body = imara_diff(
+        Algorithm::Histogram,
+        &input,
+        UnifiedDiffBuilder::new(&input),
+    );
+    if body.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!("--- baseline: {path_label}\n"));
+    out.push_str(&format!("+++ current:  {path_label}\n"));
+    out.push_str(&body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_baseline_diff;
+
+    #[test]
+    fn render_baseline_diff_empty_when_equal() {
+        let baseline = b"hello\nworld\n";
+        let current = b"hello\nworld\n";
+
+        let out = render_baseline_diff("src/a.txt", baseline, current);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn render_baseline_diff_one_line_change_contains_headers_and_hunk() {
+        let baseline = b"hello\nold\n";
+        let current = b"hello\nnew\n";
+
+        let out = render_baseline_diff("src/a.txt", baseline, current);
+        assert!(out.contains("--- baseline: src/a.txt"));
+        assert!(out.contains("+++ current:  src/a.txt"));
+        assert!(out.contains("@@"));
+        assert!(out.contains("-old"));
+        assert!(out.contains("+new"));
+    }
+
+    #[test]
+    fn render_baseline_diff_deletion_current_empty_shows_only_removals() {
+        let baseline = b"old1\nold2\n";
+        let current = b"";
+
+        let out = render_baseline_diff("src/a.txt", baseline, current);
+        assert!(out.contains("-old1"));
+        assert!(out.contains("-old2"));
+        assert!(
+            !out.lines()
+                .any(|line| line.starts_with('+') && !line.starts_with("+++"))
+        );
+    }
+
+    #[test]
+    fn render_baseline_diff_binary_baseline_or_current_prints_binary_message() {
+        let out_binary_baseline = render_baseline_diff("src/a.txt", &[0xff, 0x00], b"text\n");
+        let out_binary_current = render_baseline_diff("src/a.txt", b"text\n", &[0xff, 0x00]);
+
+        assert_eq!(out_binary_baseline, "Binary files differ: src/a.txt\n");
+        assert_eq!(out_binary_current, "Binary files differ: src/a.txt\n");
+    }
+}

--- a/plumb/src/error.rs
+++ b/plumb/src/error.rs
@@ -1,7 +1,10 @@
 use thiserror::Error;
 
 use crate::{
-    commands::{add::AddError, go::GoError, rm::RmError, start::StartError, status::StatusError},
+    commands::{
+        add::AddError, diff::DiffError, go::GoError, rm::RmError, start::StartError,
+        status::StatusError,
+    },
     fs::InputError,
     store::items::StoreError,
     workspace::WorkspaceError,
@@ -9,6 +12,8 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum PlumbError {
+    #[error("diff error: {0}")]
+    DiffError(#[from] DiffError),
     #[error("go error: {0}")]
     GoError(#[from] GoError),
     #[error("rm error: {0}")]

--- a/plumb/src/lib.rs
+++ b/plumb/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod commands;
+pub mod diff;
 pub mod error;
 pub mod fs;
 pub mod helpers;

--- a/plumb/tests/fixtures/diff/deletion.diff
+++ b/plumb/tests/fixtures/diff/deletion.diff
@@ -1,0 +1,5 @@
+--- baseline: src/a.txt
++++ current:  src/a.txt
+@@ -1,2 +1,0 @@
+-alpha
+-beta

--- a/plumb/tests/fixtures/diff/one_line_mod.diff
+++ b/plumb/tests/fixtures/diff/one_line_mod.diff
@@ -1,0 +1,6 @@
+--- baseline: src/a.txt
++++ current:  src/a.txt
+@@ -1,2 +1,2 @@
+ hello
+-world
++WORLD

--- a/plumb/tests/integration_diff.rs
+++ b/plumb/tests/integration_diff.rs
@@ -1,0 +1,380 @@
+use assert_cmd::cargo;
+use assert_cmd::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use strata::{encode::encode, map, string, value::Value};
+
+fn plumb_binary() -> Command {
+    Command::new(cargo::cargo_bin!("plumb"))
+}
+
+fn get_session_id(root: &Path) -> String {
+    fs::read_to_string(root.join(".plumb/active"))
+        .unwrap()
+        .trim()
+        .to_string()
+}
+
+fn snapshots_dir(root: &Path) -> PathBuf {
+    root.join(".plumb")
+        .join("sessions")
+        .join(get_session_id(root))
+        .join("snapshots")
+}
+
+fn items_path(root: &Path) -> PathBuf {
+    root.join(".plumb")
+        .join("sessions")
+        .join(get_session_id(root))
+        .join("items.scb")
+}
+
+fn go_with_true_editor(root: &Path, target: &str) {
+    let output = plumb_binary()
+        .current_dir(root)
+        .env("EDITOR", "true")
+        .arg("go")
+        .arg(target)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "go should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_diff(root: &Path, target: Option<&str>) -> std::process::Output {
+    let mut cmd = plumb_binary();
+    cmd.current_dir(root).arg("diff");
+    if let Some(target) = target {
+        cmd.arg(target);
+    }
+    cmd.output().unwrap()
+}
+
+fn write_items_state(root: &Path, items: Vec<(i64, &str, &str)>) {
+    let items_value = Value::List(
+        items
+            .into_iter()
+            .map(|(id, rel_path, state)| {
+                map! {
+                    "id" => strata::int!(id),
+                    "rel_path" => string!(rel_path),
+                    "state" => string!(state),
+                }
+            })
+            .collect(),
+    );
+    let encoded = encode(&items_value).unwrap();
+    fs::write(items_path(root), encoded).unwrap();
+}
+
+fn fixture(name: &str) -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("diff")
+            .join(name),
+    )
+    .unwrap()
+}
+
+#[test]
+fn diff_one_line_mod_hunk_contains_change() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "hello\nworld\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+    go_with_true_editor(root, "1");
+
+    fs::write(root.join("src/a.txt"), "hello\nWORLD\n").unwrap();
+    let output = run_diff(root, Some("1"));
+    assert!(output.status.success(), "diff should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("@@"), "stdout should contain hunk header");
+    assert!(
+        stdout.contains("-world"),
+        "stdout should contain removed line"
+    );
+    assert!(
+        stdout.contains("+WORLD"),
+        "stdout should contain added line"
+    );
+}
+
+#[test]
+fn diff_deletion_missing_current_treated_as_empty() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "alpha\nbeta\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+    go_with_true_editor(root, "1");
+
+    fs::remove_file(root.join("src/a.txt")).unwrap();
+    let output = run_diff(root, Some("1"));
+    assert!(
+        output.status.success(),
+        "diff should succeed when current file is missing"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("-alpha"));
+    assert!(stdout.contains("-beta"));
+}
+
+#[test]
+fn diff_errors_helpfully_when_baseline_missing_without_go() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "hello\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+
+    let output = run_diff(root, Some("1"));
+    assert!(!output.status.success(), "diff should fail for todo item");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    assert!(stderr.contains("baseline"));
+    assert!(stderr.contains("go"));
+}
+
+#[test]
+fn diff_no_arg_with_no_in_progress_is_success_and_empty_output() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "hello\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+
+    let output = run_diff(root, None);
+    assert!(
+        output.status.success(),
+        "diff without target should succeed"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should be empty when no item is in_progress"
+    );
+}
+
+#[test]
+fn diff_no_arg_with_two_in_progress_prints_two_headers() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "a-new\n").unwrap();
+    fs::write(root.join("src/b.txt"), "b-new\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/b.txt")
+        .assert()
+        .success();
+
+    write_items_state(
+        root,
+        vec![
+            (1, "src/a.txt", "in_progress"),
+            (2, "src/b.txt", "in_progress"),
+        ],
+    );
+    let snapshots = snapshots_dir(root);
+    fs::write(snapshots.join("1.baseline"), "a-old\n").unwrap();
+    fs::write(snapshots.join("2.baseline"), "b-old\n").unwrap();
+
+    let output = run_diff(root, None);
+    assert!(
+        output.status.success(),
+        "diff without target should succeed"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let headers = stdout.matches("--- baseline:").count();
+    assert_eq!(headers, 2, "expected two baseline headers, got: {}", stdout);
+}
+
+#[test]
+fn diff_by_id_and_by_path_match() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "hello\nworld\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+    go_with_true_editor(root, "1");
+
+    fs::write(root.join("src/a.txt"), "hello\nWORLD\n").unwrap();
+    let by_id = run_diff(root, Some("1"));
+    let by_path = run_diff(root, Some("src/a.txt"));
+
+    assert!(by_id.status.success());
+    assert!(by_path.status.success());
+    assert_eq!(by_id.stdout, by_path.stdout);
+}
+
+#[test]
+fn diff_binary_file_prints_binary_message() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.bin"), [0xff, 0x00, 0x01]).unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.bin")
+        .assert()
+        .success();
+    go_with_true_editor(root, "1");
+
+    fs::write(root.join("src/a.bin"), [0xff, 0x00, 0x02]).unwrap();
+    let output = run_diff(root, Some("1"));
+    assert!(output.status.success(), "binary diff should still succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Binary files differ: src/a.bin"));
+}
+
+#[test]
+fn golden_one_line_mod_diff_matches_fixture() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "hello\nworld\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+    go_with_true_editor(root, "1");
+
+    fs::write(root.join("src/a.txt"), "hello\nWORLD\n").unwrap();
+    let output = run_diff(root, Some("1"));
+    assert!(output.status.success());
+
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = fixture("one_line_mod.diff");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn golden_deletion_diff_matches_fixture() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.txt"), "alpha\nbeta\n").unwrap();
+
+    plumb_binary()
+        .current_dir(root)
+        .arg("start")
+        .assert()
+        .success();
+    plumb_binary()
+        .current_dir(root)
+        .arg("add")
+        .arg("src/a.txt")
+        .assert()
+        .success();
+    go_with_true_editor(root, "1");
+
+    fs::remove_file(root.join("src/a.txt")).unwrap();
+    let output = run_diff(root, Some("1"));
+    assert!(output.status.success());
+
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = fixture("deletion.diff");
+    assert_eq!(actual, expected);
+}

--- a/plumb/tests/integration_go.rs
+++ b/plumb/tests/integration_go.rs
@@ -135,53 +135,6 @@ fn go_marks_item_in_progress_and_persists() {
 }
 
 #[test]
-fn go_refuses_second_go_when_one_in_progress_and_leaves_other_todo() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let root = temp_dir.path();
-
-    plumb_binary()
-        .current_dir(root)
-        .arg("start")
-        .assert()
-        .success();
-    fs::write(root.join("a.rs"), "a").unwrap();
-    fs::write(root.join("b.rs"), "b").unwrap();
-
-    plumb_binary()
-        .current_dir(root)
-        .arg("add")
-        .arg("a.rs")
-        .assert()
-        .success();
-    plumb_binary()
-        .current_dir(root)
-        .arg("add")
-        .arg("b.rs")
-        .assert()
-        .success();
-
-    let first_go = go_with_true_editor(root, "1");
-    assert!(
-        first_go.status.success(),
-        "first go should succeed: {}",
-        String::from_utf8_lossy(&first_go.stderr)
-    );
-
-    let second_go = go_with_true_editor(root, "2");
-    assert!(!second_go.status.success(), "second go should fail");
-
-    let stderr = String::from_utf8_lossy(&second_go.stderr);
-    assert!(
-        stderr.to_lowercase().contains("already in progress"),
-        "expected in-progress error, got: {}",
-        stderr
-    );
-
-    assert_eq!(item_state(root, "a.rs"), "in_progress");
-    assert_eq!(item_state(root, "b.rs"), "todo");
-}
-
-#[test]
 fn go_missing_file_fails_leaves_todo_and_no_baseline_file() {
     let temp_dir = tempfile::tempdir().unwrap();
     let root = temp_dir.path();


### PR DESCRIPTION
## Summary
Adds a new `plumb diff` command backed by `imara-diff`, and updates the docs so `diff` can target a specific item or, when omitted, diff all `in_progress` items (no-op if none). Also loosens `go` to allow multiple `in_progress` items to support multi-file passes.

## Changes
- Introduced `plumb diff [id|file]`:
  - Diffs baseline snapshot vs current file contents
  - With no target, diffs all `in_progress` items (success + empty output if none)
  - Treats missing current files as empty (deletion diffs)
  - Handles non-UTF-8 content with `Binary files differ: <path>`
- Added `imara-diff` dependency and a shared diff renderer (`plumb/src/diff.rs`) with unit tests
- Added `plumb/src/commands/diff.rs` with supporting unit tests
- Added integration tests + golden fixtures for diff output
- Updated README + manual + snapshot concepts to reflect new diff semantics
- Updated CLI arg naming (`file` → `target`) and wired the new `diff` command into the CLI
- Removed the “only one in_progress at a time” restriction from `go` (and deleted the associated tests)

Closes #5 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diff command to operate on all in-progress items by default, or a specific item when a target is provided.
  * Added binary file detection with informative error messaging during diff operations.

* **Documentation**
  * Updated command documentation to reflect new diff semantics, behavior, and failure cases.
  * Clarified diff mechanism and multi-item support in guides.

* **Tests**
  * Added comprehensive test coverage for diff functionality, including edge cases and binary file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->